### PR TITLE
My Modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Note that [Plotly charts](https://plot.ly/) can be edited online.
 
 # Limitations
 
-It has been tested successfully with default Gatling 2.3.1, 2.1.7, 3.0.0 and 3.2.1 and 3.3.0 `simulation.log` format.
+It has been tested successfully with default Gatling 2.3.1, 2.1.7, 3.0.0, 3.1.1, 3.2.1 and 3.3.0 `simulation.log` format.
 
 # About Nuxeo
 

--- a/src/main/java/org/nuxeo/tools/gatling/report/ParserFactory.java
+++ b/src/main/java/org/nuxeo/tools/gatling/report/ParserFactory.java
@@ -35,7 +35,7 @@ public class ParserFactory {
         // System.out.println(header.size() + " " + header);
         if (header.size() == 6) {
             String version = header.get(5);
-            if (version.matches("3\\.[2-9].*")) {
+            if (version.matches("3\\.[1-9].*")) {
                 return new SimulationParserV32(file, apdexT);
             }
             if (version.startsWith("3.0")) {

--- a/src/main/java/org/nuxeo/tools/gatling/report/SimulationContext.java
+++ b/src/main/java/org/nuxeo/tools/gatling/report/SimulationContext.java
@@ -74,7 +74,7 @@ public class SimulationContext {
 
     public void addRequest(String scenario, String requestName, long start, long end, boolean success) {
         RequestStat request = reqStats.computeIfAbsent(requestName,
-                n -> new RequestStat(simulationName, scenario, n, this.start, apdexT));
+                n -> new RequestStat(simulationName, scenario, n, start, apdexT));
         request.add(start, end, success);
         simStat.add(start, end, success);
     }
@@ -83,7 +83,7 @@ public class SimulationContext {
         maxUsers = users.values().stream().mapToInt(CountMax::getMax).sum();
         simStat.computeStat(maxUsers);
         reqStats.values()
-                .forEach(request -> request.computeStat(simStat.duration, users.get(request.scenario).maximum));
+                .forEach(request -> request.computeStat(users.get(request.scenario).maximum));
     }
 
     public void setScenarioName(String name) {

--- a/src/main/java/org/nuxeo/tools/gatling/report/TrendContext.java
+++ b/src/main/java/org/nuxeo/tools/gatling/report/TrendContext.java
@@ -90,7 +90,7 @@ public class TrendContext {
                 indice = stat.indice;
                 xvalues.add(String.format("'%s'", stat.startDate));
                 yvalues.add(stat.avg);
-                yerrors.add(stat.stddev);
+                yerrors.add((long) stat.stddev);
                 rps.add(stat.rps);
             }
         }


### PR DESCRIPTION
- add support of version 3.1.X of gatling
- adjust percentile percentages to NFR
- add geometricMean calculations
- display milliseconds in startDate
- removed apdex from report
- fixed request start time to not use Simulation start time and use min request start time
- fixed calculation of request duration